### PR TITLE
fix: postal code accepts hyphen

### DIFF
--- a/src/pages/lookup.tsx
+++ b/src/pages/lookup.tsx
@@ -273,9 +273,7 @@ const Form: React.FunctionComponent = () => {
             <input
               id="form-postal"
               type="text"
-              minLength={7}
-              maxLength={8}
-              pattern="\d*"
+              pattern="\d{3}-?\d{4}"
               autoComplete="shipping postal-code"
               placeholder="郵便番号"
               className="form-field-elem w-28"


### PR DESCRIPTION
[これだけは押さえよう！住所フォームの作り方 - ケンオールブログ](https://blog.kenall.jp/entry/address-form-best-practice)

> オートコンプリート要素postal-codeはテキスト形式のため、郵便番号がハイフンを含んでいることもあります。 フォームではハイフンの有無に両方対応しておき、フォーム送信時にバックエンド[API](http://d.hatena.ne.jp/keyword/API)の要求する形式へ変換するようにしましょう。

上記記述がありますがデモアプリのコードでは `\d*` という正規表現が使われており、 `-` の入力が許可されていません。
<del>記事文中で示されたデモのURL (https://ken-all.github.io/lookup) はこのPull Request説明執筆時点で404のためデモアプリそのものの挙動を確認できたわけではありませんが、Chromeで同等のinput要素の動作を検証したところ `123-4567` のような入力が妥当と解釈されないことを確認しています。</del>
<ins>訂正されたURL (https://ken-all.github.io/kenall-js-demo/lookup) でデモを確認したところ、画面上でフィードバックはありませんが `validity.patternMismatch` がtrueになることが確認できています。</ins>

このPull Requestではハイフンを受け付けるようpattern属性を修正します。
また正規表現の数量子 (quantifier) を含めたことで不要になったためmaxlength/minlength属性を削除します。