### PR TITLE
chore: add inputMode

### DIFF
--- a/src/pages/lookup.tsx
+++ b/src/pages/lookup.tsx
@@ -274,6 +274,9 @@ const Form: React.FunctionComponent = () => {
               id="form-postal"
               type="text"
               pattern="\d{3}-?\d{4}"
+              inputMode="numeric"
+              minLength={7}
+              maxLength={8}
               autoComplete="shipping postal-code"
               placeholder="郵便番号"
               className="form-field-elem w-28"


### PR DESCRIPTION
## 概要

* #11 で修正された`pattern="\d+"` の記述はスマートフォンでテンキーを表示するためのものだった。
    * これは [`inputMode`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode) 属性の廃止に伴う非公式のワークアラウンドとして存在するもの。
    * 関連する議論: https://github.com/whatwg/html/issues/3290
* 単純にUXの向上が目的なので、いったん `inputMode` を用いて当初の意図を実現する。
* `minLength` / `maxLength` は `pattern` と関係なく指定の必要がある。

## 見た目について

### iOS 14.4 / Safari
```14.0.3 / 605.1.15```

![image](https://user-images.githubusercontent.com/18755/157120604-0a893134-85ee-4ce6-806c-6059f1f1b291.png)

### Android 11.0
```
Mozilla/5.0 (Linux; Android 11; sdk_gphone_x86_arm) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
```
![image](https://user-images.githubusercontent.com/18755/157120584-306393ed-084d-4aa0-a321-df4322d119cc.png)
